### PR TITLE
ci(release): Put back old call of setup.py

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,7 +54,7 @@ jobs:
           ls .\ladybug_grasshopper_dotnet\
 
           echo "Building distribution"
-          python -m build
+          python setup.py sdist bdist_wheel
           echo "Pushing new version to PyPi"
           twine upload dist/* -u ${{ secrets.PYPI_USERNAME }} -p ${{ secrets.PYPI_PASSWORD }}
     outputs:


### PR DESCRIPTION
I'm not sure how to resolve the use of local versions here yet:

https://github.com/ladybug-tools/ladybug-grasshopper-dotnet/actions/runs/17389459064/job/49360875153